### PR TITLE
Generate json payload from ruby hash instead of manually generating json strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@ gem install confluence-rest-api
 require 'confluence-rest-api'
 
 rest_server = 'https://myserver.com'
-user_name   = 'username'
-password    = 'password'
+auth_token  = 'personal-auth-token'
 space_key   = 'space'
 
 ##################################################################
 # A connection to the client must be done before any page requests
 ##################################################################
-client  = ConfluenceClient.new(rest_server, user_name, password)
+client  = ConfluenceClient.new(rest_server, auth_token)
 
 #################################
 # Query an existing page by title

--- a/confluence-rest-api.gemspec
+++ b/confluence-rest-api.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name    = %q{confluence-rest-api}
-  s.version = "1.2.0"
-  s.date    = %q{2021-12-01}
+  s.version = "1.2.1"
+  s.date    = %q{2023-06-24}
   s.summary = %q{Ruby REST API Client to create, update, and view pages}
   s.authors = "Gregory J. Miller, Rolf Offermanns"
   s.files   = [

--- a/confluence-rest-api.gemspec
+++ b/confluence-rest-api.gemspec
@@ -1,9 +1,9 @@
 Gem::Specification.new do |s|
   s.name    = %q{confluence-rest-api}
-  s.version = "1.1.1"
-  s.date    = %q{2020-08-25}
+  s.version = "1.2.0"
+  s.date    = %q{2021-12-01}
   s.summary = %q{Ruby REST API Client to create, update, and view pages}
-  s.authors = "Gregory J. Miller"
+  s.authors = "Gregory J. Miller, Rolf Offermanns"
   s.files   = [
       "lib/confluence-rest-api.rb", "lib/confluence.rb", "lib/page.rb", "lib/storage_format.rb", "README.md", "confluence-rest-api.gemspec"
   ]

--- a/lib/confluence.rb
+++ b/lib/confluence.rb
@@ -60,7 +60,6 @@ class ConfluenceClient
                   version:  version }
 
     update_page(PagePayload.new(page_meta).page_format, page_obj.id)
-
   end
 
   private
@@ -73,7 +72,7 @@ class ConfluenceClient
                       payload,
                       {
                         content_type: 'application/json',
-                        'Authorization': 'Bearer @@auth_token'
+                        'Authorization': "Bearer #{@@auth_token}"
                       }
     rescue RestClient::ExceptionWithResponse => error
       puts '*** ERROR: RestClient.post failed'
@@ -90,7 +89,7 @@ class ConfluenceClient
                      {
                        content_type: 'application/json',
                        accept: 'json',
-                       'Authorization': 'Bearer @@auth_token'
+                       'Authorization': "Bearer #{@@auth_token}"
                      }
     rescue RestClient::ExceptionWithResponse => error
       puts '*** ERROR: RestClient.put failed'

--- a/lib/confluence.rb
+++ b/lib/confluence.rb
@@ -3,10 +3,9 @@ require 'json'
 
 class ConfluenceClient
 
-  def initialize(url, name, password)
+  def initialize(url, token)
     @@conf_url = url
-    @@login    = name
-    @@pwd      = password
+    @@auth_token = token
     @@urn      = 'rest/api/content'
   end
 
@@ -68,9 +67,14 @@ class ConfluenceClient
 
   def create_page(payload)
 
-    url = "#{@@conf_url}/#{@@urn}?os_username=#{@@login}&os_password=#{@@pwd}"
+    url = "#{@@conf_url}/#{@@urn}"
     begin
-      RestClient.post url, payload, :content_type => 'application/json'
+      RestClient.post url,
+                      payload,
+                      {
+                        content_type: 'application/json',
+                        'Authorization': 'Bearer @@auth_token'
+                      }
     rescue RestClient::ExceptionWithResponse => error
       puts '*** ERROR: RestClient.post failed'
       pp error
@@ -79,9 +83,15 @@ class ConfluenceClient
 
   def update_page(payload, id)
 
-    url = "#{@@conf_url}/#{@@urn}/#{id}?os_username=#{@@login}&os_password=#{@@pwd}"
+    url = "#{@@conf_url}/#{@@urn}/#{id}"
     begin
-      RestClient.put url, payload, :content_type => 'application/json', :accept => 'json'
+      RestClient.put url,
+                     payload,
+                     {
+                       content_type: 'application/json',
+                       accept: 'json',
+                       'Authorization': 'Bearer @@auth_token'
+                     }
     rescue RestClient::ExceptionWithResponse => error
       puts '*** ERROR: RestClient.put failed'
       puts error

--- a/lib/confluence.rb
+++ b/lib/confluence.rb
@@ -62,6 +62,20 @@ class ConfluenceClient
     update_page(PagePayload.new(page_meta).page_format, page_obj.id)
   end
 
+  def remove_page_history(id, version_number)
+    url = "#{@@conf_url}/rest/experimental/content/#{id}/version/#{version_number}"
+    begin
+      RestClient.delete url,
+                        {
+                          'Authorization': "Bearer #{@@auth_token}"
+                        }
+    rescue RestClient::ExceptionWithResponse => e
+      puts Nokogiri.XML(e.response)
+      return nil
+    end
+    true
+  end
+
   private
 
   def create_page(payload)

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -26,7 +26,7 @@ class PageObject < ConfluenceClient
       res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}",
                            {
                              params: { expand: 'body.styled_view' },
-                             'Authorization': 'Bearer @@auth_token'
+                             'Authorization': "Bearer #{@@auth_token}"
                            }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
@@ -42,7 +42,7 @@ class PageObject < ConfluenceClient
       res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}",
                            {
                              params: { expand: 'body.view' },
-                             'Authorization': 'Bearer @@auth_token'
+                             'Authorization': "Bearer #{@@auth_token}"
                            }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
@@ -55,7 +55,7 @@ class PageObject < ConfluenceClient
       res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}",
                            {
                              params: { expand: 'body.storage' },
-                             'Authorization': 'Bearer @@auth_token'
+                             'Authorization': "Bearer #{@@auth_token}"
                            }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
@@ -67,7 +67,7 @@ class PageObject < ConfluenceClient
     begin
       RestClient.delete "#{@@conf_url}/#{@@urn}/#{page_id}",
                         {
-                          'Authorization': 'Bearer @@auth_token'
+                          'Authorization': "Bearer #{@@auth_token}"
                         }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
@@ -81,7 +81,7 @@ class PageObject < ConfluenceClient
       res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}/label",
                            {
                              params: { start: 0, limit: 500 },
-                             'Authorization': 'Bearer @@auth_token'
+                             'Authorization': "Bearer #{@@auth_token}"
                            }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
@@ -123,7 +123,7 @@ class PageObject < ConfluenceClient
                             payload,
                             {
                               content_type: 'application/json',
-                              'Authorization': 'Bearer @@auth_token'
+                              'Authorization': "Bearer #{@@auth_token}"
                             }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
@@ -146,7 +146,7 @@ class PageObject < ConfluenceClient
         uri = Addressable::URI.parse(uri).normalize.to_s
         res = RestClient.delete uri,
                                 {
-                                  'Authorization': 'Bearer @@auth_token'
+                                  'Authorization': "Bearer #{@@auth_token}"
                                 }
       rescue RestClient::ExceptionWithResponse => e
         puts Nokogiri.XML(e.response)
@@ -172,7 +172,7 @@ class PageObject < ConfluenceClient
                               content_type: 'application/json',
                               accept: 'json',
                               params: { status: 'current' },
-                              'Authorization': 'Bearer @@auth_token'
+                              'Authorization': "Bearer #{@@auth_token}"
                             }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
@@ -199,7 +199,7 @@ class PageObject < ConfluenceClient
                         payload,
                         {
                           'X-Atlassian-Token': 'nocheck',
-                          'Authorization': 'Bearer @@auth_token'
+                          'Authorization': "Bearer #{@@auth_token}"
                         })
         true
       rescue RestClient::ExceptionWithResponse => e
@@ -216,7 +216,7 @@ class PageObject < ConfluenceClient
     begin
       RestClient.delete "#{@@conf_url}/#{@@urn}/#{attach_id}",
                         {
-                          'Authorization': 'Bearer @@auth_token'
+                          'Authorization': "Bearer #{@@auth_token}"
                         }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
@@ -233,7 +233,7 @@ class PageObject < ConfluenceClient
       response = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}/child/attachment",
                                 {
                                   params: { filename: fname },
-                                  'Authorization': 'Bearer @@auth_token'
+                                  'Authorization': "Bearer #{@@auth_token}"
                                 }
       response = JSON.parse(response)
       return response['results'][0]['id'] if response['results'].any?
@@ -250,7 +250,7 @@ class PageObject < ConfluenceClient
       att_array.each do |line|
         download_hash = line.to_hash
         title = download_hash["title"]
-        url   = @@conf_url + download_hash["_links"]["download"] + "&os_username=#{@@login}&os_password=#{@@pwd}"
+        url   = @@conf_url + download_hash["_links"]["download"]
 
         File.open(storage_path + title, 'wb') {|f|
           block = proc { |response|
@@ -261,7 +261,7 @@ class PageObject < ConfluenceClient
           RestClient::Request.execute(method: :get,
                                       url: url,
                                       headers: {
-                                        'Authorization': 'Bearer @@auth_token'
+                                        'Authorization': "Bearer #{@@auth_token}"
                                       },
                                       block_response: block)
         }
@@ -288,7 +288,7 @@ class PageObject < ConfluenceClient
                                spaceKey: spacekey,
                                expand: 'version,history'
                              },
-                             'Authorization': 'Bearer @@auth_token'
+                             'Authorization': "Bearer #{@@auth_token}"
                            }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
@@ -315,7 +315,7 @@ class PageObject < ConfluenceClient
       res = RestClient.get "#{@@conf_url}/#{@@urn}/#{id}",
                            {
                              params: { expand: 'version,history' },
-                             'Authorization': 'Bearer @@auth_token'
+                             'Authorization': "Bearer #{@@auth_token}"
                            }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -2,7 +2,6 @@ require 'nokogiri'
 require 'addressable/uri'
 
 class PageObject < ConfluenceClient
-
   attr_reader :title, :id, :version, :status, :created, :created_by, :last_updated
 
   def initialize(title_or_id, spacekey)
@@ -24,9 +23,11 @@ class PageObject < ConfluenceClient
   #####################################################
   def styled_view
     begin
-      res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}", {params: {
-          :expand => 'body.styled_view', :os_username => @@login, :os_password => @@pwd
-      }}
+      res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}",
+                           {
+                             params: { expand: 'body.styled_view' },
+                             'Authorization': 'Bearer @@auth_token'
+                           }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
     end
@@ -38,9 +39,11 @@ class PageObject < ConfluenceClient
   ##################################################
   def rendered_body
     begin
-      res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}", {params: {
-          :expand => 'body.view', :os_username => @@login, :os_password => @@pwd
-      }}
+      res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}",
+                           {
+                             params: { expand: 'body.view' },
+                             'Authorization': 'Bearer @@auth_token'
+                           }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
     end
@@ -49,9 +52,11 @@ class PageObject < ConfluenceClient
 
   def storage_format
     begin
-      res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}", {params: {
-          :expand => 'body.storage', :os_username => @@login, :os_password => @@pwd
-      }}
+      res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}",
+                           {
+                             params: { expand: 'body.storage' },
+                             'Authorization': 'Bearer @@auth_token'
+                           }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
     end
@@ -60,9 +65,10 @@ class PageObject < ConfluenceClient
 
   def delete_page(page_id)
     begin
-      RestClient.delete "#{@@conf_url}/#{@@urn}/#{page_id}", {params: {
-          :os_username => @@login, :os_password => @@pwd
-      }}
+      RestClient.delete "#{@@conf_url}/#{@@urn}/#{page_id}",
+                        {
+                          'Authorization': 'Bearer @@auth_token'
+                        }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
       return nil
@@ -72,10 +78,11 @@ class PageObject < ConfluenceClient
 
   def labels
     begin
-      res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}/label", {params: {
-          :os_username => @@login, :os_password => @@pwd,
-          :start => 0, :limit => 500
-      }}
+      res = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}/label",
+                           {
+                             params: { start: 0, limit: 500 },
+                             'Authorization': 'Bearer @@auth_token'
+                           }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
       nil
@@ -112,7 +119,12 @@ class PageObject < ConfluenceClient
     # puts "Add label payload: #{payload}"
 
     begin
-      res = RestClient.post "#{@@conf_url}/#{@@urn}/#{@id}/label?os_username=#{@@login}&os_password=#{@@pwd}", payload, :content_type => 'application/json'
+      res = RestClient.post "#{@@conf_url}/#{@@urn}/#{@id}/label",
+                            payload,
+                            {
+                              content_type: 'application/json',
+                              'Authorization': 'Bearer @@auth_token'
+                            }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
     end
@@ -130,10 +142,12 @@ class PageObject < ConfluenceClient
     labels.each do |l|
       puts "Deleting label: #{l}"
       begin
-        uri = "#{@@conf_url}/#{@@urn}/#{@id}/label?name=#{l}&os_username=#{@@login}&os_password=#{@@pwd}"
+        uri = "#{@@conf_url}/#{@@urn}/#{@id}/label?name=#{l}"
         uri = Addressable::URI.parse(uri).normalize.to_s
-        res = RestClient.delete uri
-
+        res = RestClient.delete uri,
+                                {
+                                  'Authorization': 'Bearer @@auth_token'
+                                }
       rescue RestClient::ExceptionWithResponse => e
         puts Nokogiri.XML(e.response)
       end
@@ -150,10 +164,16 @@ class PageObject < ConfluenceClient
   # Return an array of all page attachment information
   def get_all_attachments(page_id)
 
-    url = "#{@@conf_url}/#{@@urn}/#{page_id}/child/attachment?os_username=#{@@login}&os_password=#{@@pwd}&status=current"
+    url = "#{@@conf_url}/#{@@urn}/#{page_id}/child/attachment"
 
     begin
-      atts = RestClient.get url, :content_type => 'application/json', :accept => 'json'
+      atts = RestClient.get url,
+                            {
+                              content_type: 'application/json',
+                              accept: 'json',
+                              params: { status: 'current' },
+                              'Authorization': 'Bearer @@auth_token'
+                            }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
       nil
@@ -173,9 +193,14 @@ class PageObject < ConfluenceClient
           comment: 'Automated Ruby import',
           minorEdit: true
       }
-      url_mod = "#{@@conf_url}/#{@@urn}/#{@id}/child/attachment?os_username=#{@@login}&os_password=#{@@pwd}"
+      url_mod = "#{@@conf_url}/#{@@urn}/#{@id}/child/attachment"
       begin
-        RestClient.post(url_mod, payload, {"X-Atlassian-Token" => "nocheck"})
+        RestClient.post(url_mod,
+                        payload,
+                        {
+                          'X-Atlassian-Token': 'nocheck',
+                          'Authorization': 'Bearer @@auth_token'
+                        })
         true
       rescue RestClient::ExceptionWithResponse => e
         puts Nokogiri.XML(e.response)
@@ -189,9 +214,10 @@ class PageObject < ConfluenceClient
 
   def delete_attachment(attach_id)
     begin
-      RestClient.delete "#{@@conf_url}/#{@@urn}/#{attach_id}", {params: {
-          :os_username => @@login, :os_password => @@pwd
-      }}
+      RestClient.delete "#{@@conf_url}/#{@@urn}/#{attach_id}",
+                        {
+                          'Authorization': 'Bearer @@auth_token'
+                        }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
       return nil
@@ -200,19 +226,17 @@ class PageObject < ConfluenceClient
   end
 
   def attachment_id(attachment_name)
-
     fname = attachment_name.dup
     fname = CGI.escape(fname)
 
     begin
-      response = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}/child/attachment", {params: {
-          :filename => fname, 'os_username' => @@login, 'os_password' => @@pwd
-      }}
-
+      response = RestClient.get "#{@@conf_url}/#{@@urn}/#{@id}/child/attachment",
+                                {
+                                  params: { filename: fname },
+                                  'Authorization': 'Bearer @@auth_token'
+                                }
       response = JSON.parse(response)
-      if response['results'].any?
-        return response['results'][0]['id']
-      end
+      return response['results'][0]['id'] if response['results'].any?
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
     end
@@ -236,6 +260,9 @@ class PageObject < ConfluenceClient
           }
           RestClient::Request.execute(method: :get,
                                       url: url,
+                                      headers: {
+                                        'Authorization': 'Bearer @@auth_token'
+                                      },
                                       block_response: block)
         }
       end
@@ -254,9 +281,15 @@ class PageObject < ConfluenceClient
   # Here we can return various metadata for a given page.
   def get_page_info_by_title(title, spacekey)
     begin
-      res = RestClient.get "#{@@conf_url}/#{@@urn}", {params: {
-          :title => title, :spaceKey => spacekey, :os_username => @@login, :os_password => @@pwd, :expand => 'version,history'
-      }}
+      res = RestClient.get "#{@@conf_url}/#{@@urn}",
+                           {
+                             params: {
+                               title: title,
+                               spaceKey: spacekey,
+                               expand: 'version,history'
+                             },
+                             'Authorization': 'Bearer @@auth_token'
+                           }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
     end
@@ -279,7 +312,11 @@ class PageObject < ConfluenceClient
 
   def get_page_info_by_id(id, spacekey)
     begin
-      res = RestClient.get "#{@@conf_url}/#{@@urn}/#{id}?os_username=#{@@login}&os_password=#{@@pwd}&expand=version,history"
+      res = RestClient.get "#{@@conf_url}/#{@@urn}/#{id}",
+                           {
+                             params: { expand: 'version,history' },
+                             'Authorization': 'Bearer @@auth_token'
+                           }
     rescue RestClient::ExceptionWithResponse => e
       puts Nokogiri.XML(e.response)
     end

--- a/lib/storage_format.rb
+++ b/lib/storage_format.rb
@@ -3,7 +3,7 @@ class PagePayload
 
   VALID_OPTIONS = [:type, :title, :spacekey, :content, :pageid, :parentid, :version]
 
-  def initialize(**options)
+  def initialize(options)
     options.each do |key, value|
       # puts "--> #{key} = #{value}"
       raise "\n*** Error: unknown option #{key.inspect}\nValid option are:\n#{VALID_OPTIONS}" unless (VALID_OPTIONS.include?(key))

--- a/lib/storage_format.rb
+++ b/lib/storage_format.rb
@@ -20,94 +20,100 @@ class PagePayload
         puts "*** ERROR: Undefined parameter(s)\n    Inspection: #{self.inspect}"
         exit(false)
       else
-        %Q(
-        {
-          "type": "page",
-          "title": "#{@title}",
-          "space": {
-            "key": "#{@spacekey}"
+        p = {
+          type: 'page',
+          title: @title,
+          space: {
+            key: @spacekey
           },
-          "body": {
-            "storage": {
-              "value": "#{@content}",
-                "representation": "storage"
+          body: {
+            storage: {
+              value: @content,
+              representation: 'storage'
             }
           }
         }
-        )
+        p.to_json
       end
     when 'create_page_with_parent'
       if [@parentid, @title, @spacekey, @content].include?(nil)
         puts "*** ERROR: Undefined parameter(s)\n    Inspection: #{self.inspect}"
         exit(false)
       else
-        %Q(
-        {
-            "type": "page",
-            "ancestors": [{"type":"page","id":"#{@parentid}"}],
-            "title": "#{@title}",
-            "space": {
-                "key": "#{@spacekey}"
-            },
-            "body": {
-                "storage": {
-                    "value": "#{@content}",
-                    "representation": "storage"
-                }
+        p = {
+          type: 'page',
+          ancestors: [
+            {
+              type: 'page',
+              id: @parentid
             }
+          ],
+          title: @title,
+          space: {
+            key: @spacekey
+          },
+          body: {
+            storage: {
+              value: @content,
+              representation: 'storage'
+            }
+          }
         }
-        )
+        p.to_json
       end
     when 'update_page_with_no_parent'
       if [@pageid, @title, @spacekey, @content, @version].include?(nil)
         puts "*** ERROR: Undefined parameter(s)\n    Inspection: #{self.inspect}"
         exit(false)
       else
-        %Q(
-        {
-            "id":"#{@pageid}",
-            "type":"page",
-            "title":"#{@title}",
-            "space": {
-                "key":"#{@spacekey}"
-            },
-            "body": {
-                "storage": {
-                    "value":"#{@content}",
-                    "representation":"storage"
-                }
-            },
-            "version": {
-                "number":"#{@version}"
+        p = {
+          id: @pageid,
+          type: 'page',
+          title: @title,
+          space: {
+            key: @spacekey
+          },
+          body: {
+            storage: {
+              value: @content,
+              representation: 'storage'
             }
+          },
+          version: {
+            number: @version.to_i
+          }
         }
-        )
+        p.to_json
       end
     when 'update_page_with_parent'
       if [@pageid, @parentid, @title, @spacekey, @content, @version].include?(nil)
         puts "*** ERROR: Undefined parameter(s)\n    Inspection: #{self.inspect}"
         exit(false)
       else
-        %Q(
-        {
-            "id":"#{@pageid}",
-            "type":"page",
-            "ancestors": [{"type":"page","id":"#{@parentid}"}],
-            "title":"#{@title}",
-            "space": {
-                "key":"#{@spacekey}"
-            },
-            "body": {
-                "storage": {
-                    "value":"#{@content}",
-                    "representation":"storage"
-                }
-            },
-            "version": {
-                "number":"#{@version}"
+        p = {
+          id: @pageid,
+          type: 'page',
+          ancestors: [
+            {
+              type: 'page',
+              id: @parentid
             }
+          ],
+          title: @title,
+          space: {
+            key: @spacekey
+          },
+          body: {
+            storage: {
+              value: @content,
+              representation: 'storage'
+            }
+          },
+          version: {
+            number: @version.to_i
+          }
         }
-        )
+        p.to_json
       end
     else
       puts "***ERROR: Wrong parameters for #{self.class.name}"


### PR DESCRIPTION
The original method failed in my tests for any non-trivial page content.